### PR TITLE
Add support for "39." as a dollar value #=> 3900 cents

### DIFF
--- a/lib/has_money.rb
+++ b/lib/has_money.rb
@@ -32,7 +32,7 @@ module HasMoney
 
       dollars = dollars.to_s.gsub(/[$,]/, "").strip
       dollars[0] = '0.' if dollars =~ /^\.\d{1,2}/
-      return nil unless dollars.match(/^\d+(\.\d+)?$/) # xx.xxx
+      return nil unless dollars.match(/^\d+\.?(\d+)?$/) # xx.xxx
 
       (BigDecimal(dollars).round(2) * 100).to_i
     end

--- a/spec/has_money_spec.rb
+++ b/spec/has_money_spec.rb
@@ -79,6 +79,11 @@ describe HasMoney do
       @product.price_in_dollars = '39.992'
       @product.price.should == 3999
     end
+
+    it "should assume zero cents if none given after decimal point" do
+      @product.price_in_dollars = '39.'
+      @product.price.should == 3900
+    end
     
     it "should set nil if nil is passed as dollars" do
       @product.price_in_dollars = nil


### PR DESCRIPTION
This commit adds support for submitting a value such as "39." which should result in "39.00".

Before this commit, it would return nil.
